### PR TITLE
fix incorrect image name, fix deprecation warnings from Docker

### DIFF
--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -4,22 +4,22 @@ WORKDIR /tmp
 
 # basic compiler and linker tools
 RUN dnf install -y -d1 @development-tools \
-# rpmbuild
+# rpmbuild \
   rpm-build \
   rpmdevtools \
   redhat-rpm-config \
   fedora-packager \
-# fpm deps
+# fpm deps \
   rubygems \
   libffi-devel \
   ruby-devel \
-# pip + virtualenv
+# pip + virtualenv \
   python-pip \
 && pip install virtualenv \
-# install fpm
+# install fpm \
 && gem install fpm --no-rdoc --no-ri \
-# The rpmdev-setuptree program will create the ~/rpmbuild directory and a set of subdirectories (e.g. SPECS and BUILD)
+# The rpmdev-setuptree program will create the ~/rpmbuild directory and a set of subdirectories (e.g. SPECS and BUILD) \
 && rpmdev-setuptree \
-# clean up the cache
-&& dnf clean all --enablerepo=\*
-
+# clean up the cache \
+&& dnf clean all \
+&& rpm --rebuilddb

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -4,22 +4,23 @@ WORKDIR /tmp
 
 # basic compiler and linker tools
 RUN dnf install -y -d1 @development-tools \
-# rpmbuild
+# rpmbuild \
   rpm-build \
   rpmdevtools \
   redhat-rpm-config \
   fedora-packager \
-# fpm deps
+# fpm deps \
   rubygems \
   libffi-devel \
   ruby-devel \
-# pip + virtualenv
+# pip + virtualenv \
   python-pip \
 && pip install virtualenv \
-# install fpm
+# install fpm \
 && gem install fpm --no-rdoc --no-ri \
-# The rpmdev-setuptree program will create the ~/rpmbuild directory and a set of subdirectories (e.g. SPECS and BUILD)
+# The rpmdev-setuptree program will create the ~/rpmbuild directory and a set of subdirectories (e.g. SPECS and BUILD) \
 && rpmdev-setuptree \
-# clean up the cache
-&& dnf clean all --enablerepo=\*
+# clean up the cache \
+&& dnf clean all \
+&& rpm --rebuilddb
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE := quay.io/getpantheon/rpmbuid-fedora
+IMAGE := quay.io/getpantheon/rpmbuild-fedora
 LATEST := 24
 VERSIONS := 22 24
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ on quay.io or access to the getpantheon org on quay.io.
 - If you only want to build a specific version or versions, set the `VERSIONS` make
 variable, eg:
 
-    make all VERSIONS="22"
-
-    make build buid VERSIONS="20 22"
+    make build VERSIONS="20 22"
 
 - If you just want a local build invoke `make build`
 - use `make` without args to get a list of tasks


### PR DESCRIPTION
- fixed incorrect image name `buid`
- fix "blank continuation line detected" deprecation warning from docker
- add an `rpm --rebuilddb` to end of build. This has helped some issues
such as in the php build scripts.