### PR TITLE
problem: circle builds failing due to retired docker-login flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,6 @@ jobs:
           name: push image to quay.io
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-              docker login -p "$QUAY_PASSWD" -u "$QUAY_USER" -e "unused@unused" quay.io
+              docker login -p "$QUAY_PASSWD" -u "$QUAY_USER" quay.io
               make push
             fi


### PR DESCRIPTION
solution: remove the -e flag from the docker-login calls.