### PR TITLE
Enable building against backported packages

### DIFF
--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -2,6 +2,9 @@ FROM fedora:22
 
 WORKDIR /tmp
 
+# install pantheon fedora-fastforward
+RUN curl -s https://59ca2705d0e99cf3e33ac076713ebd13d90ca80b65b2e3e5:@packagecloud.io/install/repositories/pantheon/fedora-fastforward/script.rpm.sh | sudo bash
+
 # basic compiler and linker tools
 RUN dnf install -y -d1 @development-tools \
 # rpmbuild \


### PR DESCRIPTION
In cases where we have backported libraries that other packages/builds
may depend on we want to ensure the build container has access to these
libs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/rpmbuild-fedora-docker/11)
<!-- Reviewable:end -->
