### PR TITLE
add docker client to f28 images

### DIFF
--- a/28/Dockerfile
+++ b/28/Dockerfile
@@ -24,6 +24,11 @@ RUN dnf install -y -d1 @development-tools \
 # clean up the cache \
 && dnf clean all
 
+# install docker edge releases. This is needed for some CI jobs that need to interact with a docker instance (pantheon-php is one example)
+RUN dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo \
+    && dnf config-manager --set-enabled docker-ce-edge \
+    && dnf install -y -d1 docker-ce
+
 # for builds that may need a user
 RUN useradd -ms /bin/bash -d /work builder
 RUN echo "builder ALL = NOPASSWD:ALL" >> /etc/sudoers.d/builder


### PR DESCRIPTION
This is primarily for the pantheon-php repo which will now be building
docker images (cos-runtime-php) in additional to RPMs in order to
support the COS project. The CircleCI jobs utilize this container and
thus need docker client to interact with circle's remote_docker
instances.