### PR TITLE
[CMS-649] Update deprecated docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: ~/rpmbuild-fedora-docker
     steps:
       - checkout


### PR DESCRIPTION
As per https://circleci.com/blog/ubuntu-14-16-image-deprecation/ the docker image used in this repo is going unsupported at the end of current month. This PR attempts to update it.

It may break things though so please make sure builds work correctly before merging.